### PR TITLE
Fix naming of envvars prefix for apps loaded from submodules

### DIFF
--- a/flask_appconfig/__init__.py
+++ b/flask_appconfig/__init__.py
@@ -22,7 +22,7 @@ class AppConfig(object):
                  enable_cli=True):
 
         if from_envvars_prefix is None:
-            from_envvars_prefix = app.name.upper() + '_'
+            from_envvars_prefix = app.name.upper().replace('.', '_') + '_'
 
         if default_settings is True:
             defs = try_import(app.name + '.default_config')

--- a/tests/test_appenv.py
+++ b/tests/test_appenv.py
@@ -15,3 +15,18 @@ def test_envmocking(monkeypatch):
     app = create_sample_app()
     assert app.config['CONFA'] == 'a'
     assert app.config['CONFB'] == 'b'
+
+
+def create_submodule_app():
+    app = Flask('module.app')
+    AppConfig(app)
+    return app
+
+
+def test_envmocking_app_in_submodule(monkeypatch):
+    monkeypatch.setenv('MODULE_APP_CONFA', 'a')
+    monkeypatch.setenv('MODULE_APP_CONFB', 'b')
+
+    app = create_submodule_app()
+    assert app.config['CONFA'] == 'a'
+    assert app.config['CONFB'] == 'b'


### PR DESCRIPTION
In bash (and probably other shells as well), dots are not allowed to be part of environment variable name. This means that if the app lives in a submodule, we should replace dots with underscores. E.g. if app is called `foo.bar`, it should read settings from `FOO_BAR_*` env variables.